### PR TITLE
Raw json requests

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -79,6 +79,14 @@ requests:
         friend_id: ${session.friendIds}
         say: ${say}
 
+    #
+    - POST: /json/data/receiver
+      params:
+        raw_body: |
+          {"token":"ololo","key_id":"trololo"}
+      headers:
+          Content-type: application/json
+
     # SYNC - в этой группе выполнятся все запросы в том порядке, в котором заданы. SYNC может находится как внутри RANDOM, так и во вне ее
     - SYNC:
       - GET: /some/path?query=2

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -79,7 +79,7 @@ requests:
         friend_id: ${session.friendIds}
         say: ${say}
 
-    #
+    # to send raw json body you have to specify request's raw_body in params AND set content-type headers to application/json
     - POST: /json/data/receiver
       params:
         raw_body: |

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -230,9 +230,7 @@ func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, ca
                         break
 
                     }
-                    defer request.Body.Close()
 					request.ContentLength = int64(body.Len())
-
                 }
 
 				if reporter.Debug {

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -207,7 +207,7 @@ func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, ca
                         }
                         writer.Close()
                         request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-                        request.Header.Set("Content-Type", writer.FormDataContentType())\
+                        request.Header.Set("Content-Type", writer.FormDataContentType())
                         break
                     case "application/json":
                         for _, feature := range cartridge.chargeFeatures {

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -23,6 +23,9 @@ var (
 	kill = &Kill{shotsCount: 0}
 )
 
+
+
+
 type Kill struct {
 	shotsCount    int
 	GunsCount     int           `yaml:"concurrency"`
@@ -152,7 +155,8 @@ func (this *Killer) charge(shots chan *Shot) {
 }
 
 func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, cartridges Cartridges) {
-	for _, cartridge := range cartridges {
+
+    for _, cartridge := range cartridges {
 		if cartridge.getMethod() == RANDOM_METHOD || cartridge.getMethod() == SYNC_METHOD {
 			this.chargeCartidges(shots, client, cartridge.getChildren())
 		} else {
@@ -194,31 +198,48 @@ func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, ca
 				this.setFeatures(request, this.gun.Features)
 				this.setFeatures(request, cartridge.bulletFeatures)
 				if isPostRequest {
-					if request.Header.Get("Content-Type") == "multipart/form-data" {
-						writer := multipart.NewWriter(&body)
-						for _, feature := range cartridge.chargeFeatures {
-							writer.WriteField(feature.name, feature.String(this))
-						}
-						writer.Close()
-						request.Header.Set("Content-Type", writer.FormDataContentType())
-					} else {
-						params := url.Values{}
-						for _, feature := range cartridge.chargeFeatures {
-							params.Set(feature.name, feature.String(this))
-						}
-						body.WriteString(params.Encode())
-						if len(request.Header.Get("Content-Type")) == 0 {
-							request.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-						}
-					}
+
+                    switch request.Header.Get("Content-Type") {
+                    case "multipart/form-data":
+                        writer := multipart.NewWriter(&body)
+                        for _, feature := range cartridge.chargeFeatures {
+                            writer.WriteField(feature.name, feature.String(this))
+                        }
+                        writer.Close()
+                        request.Header.Set("Content-Type", writer.FormDataContentType())
+
+                        break
+                    case "application/json":
+                        for _, feature := range cartridge.chargeFeatures {
+                            if feature.name == "raw_body" {
+                                body.WriteString(feature.String(this))
+                            }
+                        }
+                        request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
+                        request.Header.Set("Content-Type", "application/json")
+                        break
+                    default:
+                        params := url.Values{}
+                        for _, feature := range cartridge.chargeFeatures {
+                            params.Set(feature.name, feature.String(this))
+                        }
+                        body.WriteString(params.Encode())
+                        if len(request.Header.Get("Content-Type")) == 0 {
+                            request.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+                        }
+                        break
+
+                    }
+                    defer request.Body.Close()
 					request.ContentLength = int64(body.Len())
-				}
+
+                }
 
 				if reporter.Debug {
 					reporter.log("create request:")
 					dump, _ := httputil.DumpRequest(request, true)
 					reporter.log(string(dump))
-				}
+                }
 				shot.request = request
 				shots <- shot
 			} else {

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -206,8 +206,8 @@ func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, ca
                             writer.WriteField(feature.name, feature.String(this))
                         }
                         writer.Close()
-                        request.Header.Set("Content-Type", writer.FormDataContentType())
-
+                        request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
+                        request.Header.Set("Content-Type", writer.FormDataContentType())\
                         break
                     case "application/json":
                         for _, feature := range cartridge.chargeFeatures {
@@ -224,6 +224,7 @@ func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, ca
                             params.Set(feature.name, feature.String(this))
                         }
                         body.WriteString(params.Encode())
+                        request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
                         if len(request.Header.Get("Content-Type")) == 0 {
                             request.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
                         }

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -1,30 +1,27 @@
 package lib
 
 import (
-	"time"
+	"bytes"
 	"errors"
 	"fmt"
-	"runtime"
+	"github.com/cheggaaa/pb"
+	"golang.org/x/net/publicsuffix"
+	"io/ioutil"
+	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
-	"net"
-	"strings"
-	"net/url"
-	"mime/multipart"
-	"bytes"
 	"net/http/httputil"
+	"net/url"
+	"runtime"
+	"strings"
 	"sync"
-	"github.com/cheggaaa/pb"
-	"io/ioutil"
-	"golang.org/x/net/publicsuffix"
+	"time"
 )
 
 var (
 	kill = &Kill{shotsCount: 0}
 )
-
-
-
 
 type Kill struct {
 	shotsCount    int
@@ -154,9 +151,9 @@ func (this *Killer) charge(shots chan *Shot) {
 	this.chargeCartidges(shots, client, this.gun.Cartridges)
 }
 
-func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, cartridges Cartridges) {
+func (this *Killer) chargeCartidges(shots chan<- *Shot, client *http.Client, cartridges Cartridges) {
 
-    for _, cartridge := range cartridges {
+	for _, cartridge := range cartridges {
 		if cartridge.getMethod() == RANDOM_METHOD || cartridge.getMethod() == SYNC_METHOD {
 			this.chargeCartidges(shots, client, cartridge.getChildren())
 		} else {
@@ -173,10 +170,10 @@ func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, ca
 			shot.client = client
 			shot.transport = &http.Transport{
 				Dial: func(network, addr string) (conn net.Conn, err error) {
-					return net.DialTimeout(network, addr, time.Second * timeout)
+					return net.DialTimeout(network, addr, time.Second*timeout)
 				},
 				ResponseHeaderTimeout: time.Second * timeout,
-				DisableKeepAlives: true,
+				DisableKeepAlives:     true,
 			}
 
 			reqUrl := new(url.URL)
@@ -199,46 +196,46 @@ func (this *Killer) chargeCartidges(shots chan <- *Shot, client *http.Client, ca
 				this.setFeatures(request, cartridge.bulletFeatures)
 				if isPostRequest {
 
-                    switch request.Header.Get("Content-Type") {
-                    case "multipart/form-data":
-                        writer := multipart.NewWriter(&body)
-                        for _, feature := range cartridge.chargeFeatures {
-                            writer.WriteField(feature.name, feature.String(this))
-                        }
-                        writer.Close()
-                        request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-                        request.Header.Set("Content-Type", writer.FormDataContentType())\
-                        break
-                    case "application/json":
-                        for _, feature := range cartridge.chargeFeatures {
-                            if feature.name == "raw_body" {
-                                body.WriteString(feature.String(this))
-                            }
-                        }
-                        request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-                        request.Header.Set("Content-Type", "application/json")
-                        break
-                    default:
-                        params := url.Values{}
-                        for _, feature := range cartridge.chargeFeatures {
-                            params.Set(feature.name, feature.String(this))
-                        }
-                        body.WriteString(params.Encode())
-                        request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-                        if len(request.Header.Get("Content-Type")) == 0 {
-                            request.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-                        }
-                        break
+					switch request.Header.Get("Content-Type") {
+					case "multipart/form-data":
+						writer := multipart.NewWriter(&body)
+						for _, feature := range cartridge.chargeFeatures {
+							writer.WriteField(feature.name, feature.String(this))
+						}
+						writer.Close()
+						request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
+						request.Header.Set("Content-Type", writer.FormDataContentType())
+						break
+					case "application/json":
+						for _, feature := range cartridge.chargeFeatures {
+							if feature.name == "raw_body" {
+								body.WriteString(feature.String(this))
+							}
+						}
+						request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
+						request.Header.Set("Content-Type", "application/json")
+						break
+					default:
+						params := url.Values{}
+						for _, feature := range cartridge.chargeFeatures {
+							params.Set(feature.name, feature.String(this))
+						}
+						body.WriteString(params.Encode())
+						request.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
+						if len(request.Header.Get("Content-Type")) == 0 {
+							request.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+						}
+						break
 
-                    }
+					}
 					request.ContentLength = int64(body.Len())
-                }
+				}
 
 				if reporter.Debug {
 					reporter.log("create request:")
 					dump, _ := httputil.DumpRequest(request, true)
 					reporter.log(string(dump))
-                }
+				}
 				shot.request = request
 				shots <- shot
 			} else {
@@ -254,7 +251,7 @@ func (this *Killer) setFeatures(request *http.Request, features Features) {
 	}
 }
 
-func (this *Killer) fire(hits chan <- *Hit, shots <- chan *Shot, group *sync.WaitGroup, bar *pb.ProgressBar) {
+func (this *Killer) fire(hits chan<- *Hit, shots <-chan *Shot, group *sync.WaitGroup, bar *pb.ProgressBar) {
 	for shot := range shots {
 		hit := new(Hit)
 		hit.shot = shot
@@ -288,7 +285,7 @@ type Hit struct {
 }
 
 const (
-	HTTP_SCHEME = "http"
+	HTTP_SCHEME  = "http"
 	HTTPS_SCHEME = "https"
 )
 

--- a/mgun.go
+++ b/mgun.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"fmt"
-	"./lib"
+	"github.com/thefish/mgun/lib"
 	yaml "gopkg.in/yaml.v2"
+	"io/ioutil"
 )
 
 func main() {

--- a/mgun.go
+++ b/mgun.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"fmt"
-	"github.com/byorty/mgun/lib"
+	"./lib"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -21,7 +21,6 @@ func main() {
 			victim := lib.NewVictim()
 			gun := lib.GetGun()
 			reporter := lib.GetReporter()
-
 			err := yaml.Unmarshal(bytes, kill)
 			if err == nil {
 				err = yaml.Unmarshal(bytes, victim)

--- a/mgun.go
+++ b/mgun.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/thefish/mgun/lib"
+	"github.com/byorty/mgun/lib"
 	yaml "gopkg.in/yaml.v2"
 	"io/ioutil"
 )


### PR DESCRIPTION
Pull request allows to send raw JSON body with POST methods, also fixes some issues with POST params.

usage example: 
```yaml
concurrency: 1000
loopCount: 10
timeout: 5
host: localhost
port: 8080
requests:
  - RANDOM:
    - POST: /get-info-by-pan
      params:
        raw_body: |
          {"panPart":554771182}
      headers:
          Content-type: application/json
    - POST: /get-info-by-pan
      params:
        raw_body: |
          {"panPart":67759901}
      headers:
          Content-type: application/json
    - POST: /get-info-by-pan
      params:
        raw_body: |
          {"panPart":544919181}
      headers:
          Content-type: application/json
    - POST: /get-info-by-pan
      params:
        raw_body: |
          {"panPart":5547132}
      headers:
          Content-type: application/json

```

